### PR TITLE
增加导出后在 Finder 中打开的功能

### DIFF
--- a/marketch.sketchplugin/Contents/Sketch/util.cocoascript
+++ b/marketch.sketchplugin/Contents/Sketch/util.cocoascript
@@ -160,6 +160,7 @@ var util = {
                 'ARTBOARDONPAGE': '当前页面上的全部画板',
                 'ALLARTBOARD': '所有画板(会比较慢)',
                 'EXPORTEVERYLAYER': '把每个图层作为图片导出',
+                'REVEALINFINDER': '导出完成后在 Finder 中打开',
                 'CONFIRM': '确认',
                 'CANCEl': '取消',
                 //预览页面多语言
@@ -198,6 +199,7 @@ var util = {
                 'ARTBOARDONPAGE': 'Artboards on current page',
                 'ALLARTBOARD': 'All Artboards',
                 'EXPORTEVERYLAYER': 'Export all layers as image',
+                'REVEALINFINDER': 'Reveal in Finder after exporting',
                 'CONFIRM': 'Confirm',
                 'CANCEl': 'Cancel',
                 //预览页面多语言

--- a/marketch.sketchplugin/Contents/Sketch/zip.cocoascript
+++ b/marketch.sketchplugin/Contents/Sketch/zip.cocoascript
@@ -45,6 +45,11 @@ ExportAsZip.prototype = {
                 if(zipResult){
                     //task执行成功
                     doc.showMessage(I18N.EXPORTSUCCESS);
+                    if (expConfig.reveal) {
+                        var zipURL = [NSURL fileURLWithPath: exportPath];
+                        var fileURLs = [NSArray arrayWithObjects:zipURL, nil];
+                        [[NSWorkspace sharedWorkspace] activateFileViewerSelectingURLs:fileURLs];
+                    }
                 }else{
                     doc.showMessage(I18N.EXPORTFAIL);
                 }
@@ -57,7 +62,8 @@ ExportAsZip.prototype = {
         var altWin = COSAlertWindow.new();
         var items = [I18N.SELECTEDARTBOARD, I18N.ARTBOARDONPAGE, I18N.ALLARTBOARD];
         var comboBox = NSComboBox.alloc().initWithFrame(NSMakeRect(0,0,200,25));
-        var checkBox = NSButton.alloc().initWithFrame(NSMakeRect(0,0,250,25));
+        var exportBox = NSButton.alloc().initWithFrame(NSMakeRect(0,0,250,25));
+        var revealBox = NSButton.alloc().initWithFrame(NSMakeRect(0,0,250,25));
 
         altWin.setMessageText('Marketch');
         altWin.setInformativeText(I18N.SELECTEXPORTARTBOARD);
@@ -67,12 +73,17 @@ ExportAsZip.prototype = {
         comboBox.addItemsWithObjectValues(items);
         comboBox.selectItemAtIndex(2);
         
-        checkBox.setTitle(I18N.EXPORTEVERYLAYER);
-        checkBox.setButtonType(NSSwitchButton);
-        checkBox.setState(true);
+        exportBox.setTitle(I18N.EXPORTEVERYLAYER);
+        exportBox.setButtonType(NSSwitchButton);
+        exportBox.setState(true);
+        
+        revealBox.setTitle(I18N.REVEALINFINDER);
+        revealBox.setButtonType(NSSwitchButton);
+        revealBox.setState(true);
         
         altWin.addAccessoryView(comboBox);
-        altWin.addAccessoryView(checkBox);
+        altWin.addAccessoryView(exportBox);
+        altWin.addAccessoryView(revealBox);
 
         return {
             //用户点击按钮 确认返回1000，取消返回1001
@@ -80,7 +91,9 @@ ExportAsZip.prototype = {
             //需要导出的画板返回值为索引
             artboard: comboBox.indexOfSelectedItem(),
             //是否导出每个图层的图片
-            layer: checkBox.state()
+            layer: exportBox.state(),
+            //是否在导出完成后打开 Finder
+            reveal: revealBox.state()
         }
     },
 


### PR DESCRIPTION
感觉每次导出后要从 Finder 中手动打开太麻烦了，于是添加了这个自动打开 Finder 并且高亮 zip 包的功能。

在弹出的选项框中增加了一个选项，选中后导出就会弹出 Finder，并且打开对应路径，高亮导出的文件，效果如图：

![image](https://cloud.githubusercontent.com/assets/4675950/10342044/d53b4dcc-6d49-11e5-9e9c-31444c33c9c1.png)

