### PR TITLE
Fix: 新版Chrome，Firefox中选中目标变为黑色问题

### DIFF
--- a/marketch.sketchplugin/Contents/Sketch/index.html
+++ b/marketch.sketchplugin/Contents/Sketch/index.html
@@ -83,7 +83,7 @@ input[type=text], textarea {outline:0;padding:3px;}
         .wrap-slice-active .art-slice {display:block;border:1px dashed #D6D6D6;border-radius:2px;}
         .wrap-slice-active .art-slice:hover, .wrap-slice-active .art-slice-active {border-color:#FE3B00;}
 
-    .sketch-marker {position:absolute;visibility:hidden;top:140px;left:300px;z-index:2;box-shadow: 0 0 0 1px #FE3B00;width:200px;height:200px;text-align:center;vertical-align:middle;pointer-events:none;background:rgba(0,0,0);}
+    .sketch-marker {position:absolute;visibility:hidden;top:140px;left:300px;z-index:2;box-shadow: 0 0 0 1px #FE3B00;width:200px;height:200px;text-align:center;vertical-align:middle;pointer-events:none;background:rgba(0,0,0,0);}
       .sketch-marker-disable b {visibility:hidden;}
       .sketch-marker span {position:absolute;z-index:2;width:5px;height:5px;border:1px solid #FE3B00;border-radius:100%;background:#fff;}
       .sketch-marker .skm-tl {top:-4px;left:-4px;}


### PR DESCRIPTION
在旧版 Chrome，旧版 Firefox，Safari，IE，Edge 中，都不能正确识别 background:rgba(0,0,0);
所以在早期插件生成的html在选中无素时没有背景。

但在新版 Chrome，新版 Firefox 中把 background:rgba(0,0,0) 识别为黑色，导致了生成的 html 在选中元素变成了黑色的问题。改为规范的rgba(0,0,0,0)则正常。

测试数据：
最新 Chrome 有问题，能识别 rgba(0,0,0)为黑色；
最新 Firefox 有问题，能识别 rgba(0,0,0)为黑色；

旧版 Chrome 57 没问题，不能识别 rgba(0,0,0)；
旧版 Firefox 55 没问题，不能识别 rgba(0,0,0)；
IE/Edge/Safari 没问题，不能识别 rgba(0,0,0)；
